### PR TITLE
feat: add pre-commit hook support for other repos

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: owasp-agentic-scan
+  name: OWASP Agentic AI Scanner
+  description: Scan for OWASP Agentic AI Top 10 security risks
+  entry: owasp-scan scan
+  language: python
+  types: [python]
+  require_serial: true
+  minimum_pre_commit_version: "2.9.0"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,37 @@ owasp-scan list-rules
 eval(expression)  # noqa: AA05
 ```
 
+## Pre-commit Integration
+
+### As a Pre-commit Hook (Recommended)
+
+Add to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/NP-compete/owasp-agentic-ai-security-scanner
+    rev: v0.1.0
+    hooks:
+      - id: owasp-agentic-scan
+        args: [--min-severity, high]
+```
+
+### As a Local Hook
+
+If you have the scanner installed locally:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: owasp-agentic-scan
+        name: OWASP Agentic AI Scanner
+        entry: owasp-scan scan src --min-severity high
+        language: system
+        pass_filenames: false
+        always_run: true
+```
+
 ## CI/CD Integration
 
 ### GitHub Actions
@@ -67,6 +98,18 @@ eval(expression)  # noqa: AA05
 - uses: github/codeql-action/upload-sarif@v4
   with:
     sarif_file: results.sarif
+```
+
+### GitLab CI
+
+```yaml
+security-scan:
+  script:
+    - pip install owasp-agentic-scanner
+    - owasp-scan scan src --format json --output gl-sast-report.json
+  artifacts:
+    reports:
+      sast: gl-sast-report.json
 ```
 
 ## Development

--- a/docs/PRE_COMMIT.md
+++ b/docs/PRE_COMMIT.md
@@ -1,0 +1,115 @@
+# Pre-commit Integration
+
+Use the OWASP Agentic AI Scanner as a pre-commit hook to catch security issues before they're committed.
+
+## Option 1: As a Pre-commit Hook (Recommended)
+
+Add directly to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/NP-compete/owasp-agentic-ai-security-scanner
+    rev: v0.1.0  # Use latest release tag
+    hooks:
+      - id: owasp-agentic-scan
+```
+
+### With Options
+
+```yaml
+repos:
+  - repo: https://github.com/NP-compete/owasp-agentic-ai-security-scanner
+    rev: v0.1.0
+    hooks:
+      - id: owasp-agentic-scan
+        args: [--min-severity, high]  # Only high/critical
+```
+
+```yaml
+repos:
+  - repo: https://github.com/NP-compete/owasp-agentic-ai-security-scanner
+    rev: v0.1.0
+    hooks:
+      - id: owasp-agentic-scan
+        args: [--rules, goal_hijack,code_execution]  # Specific rules
+```
+
+## Option 2: As a Local Hook
+
+If you prefer to install the scanner in your project:
+
+```bash
+pip install owasp-agentic-scanner
+# or
+uv add owasp-agentic-scanner
+```
+
+Then add to `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: owasp-agentic-scan
+        name: OWASP Agentic AI Scanner
+        entry: owasp-scan scan src
+        language: system
+        pass_filenames: false
+        always_run: true
+```
+
+### Customized Local Hook
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: owasp-agentic-scan
+        name: OWASP Agentic AI Scanner
+        entry: owasp-scan scan src --min-severity high --rules goal_hijack,code_execution
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+```
+
+## Available Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--min-severity` | Minimum severity: `critical`, `high`, `medium`, `low`, `info` |
+| `--rules` | Comma-separated rule names or IDs (e.g., `goal_hijack,AA02`) |
+| `--format` | Output format: `console`, `json`, `sarif` |
+| `-v, --verbose` | Show detailed findings |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | No critical/high findings (pass) |
+| 1 | Critical/high findings detected (fail) |
+
+## Recommended Setup
+
+For most projects, use `--min-severity high` to focus on critical issues:
+
+```yaml
+repos:
+  - repo: https://github.com/NP-compete/owasp-agentic-ai-security-scanner
+    rev: v0.1.0
+    hooks:
+      - id: owasp-agentic-scan
+        args: [--min-severity, high]
+```
+
+## Suppressing False Positives
+
+Use inline comments to suppress specific findings:
+
+```python
+# Suppress a single rule
+eval(expression)  # noqa: AA05
+
+# Suppress multiple rules
+dangerous_code()  # noqa: AA01, AA05
+```


### PR DESCRIPTION
## Summary

Enables other repositories to use the OWASP Agentic AI Scanner as a pre-commit hook.

## Changes

- Add `.pre-commit-hooks.yaml` for direct pre-commit integration
- Add `docs/PRE_COMMIT.md` with detailed usage guide
- Update README with pre-commit and GitLab CI examples

## Checklist

- [x] `make pre-commit` passes
- [x] Tests added/updated
- [x] Documentation updated (if applicable)

## Related Issues

N/A