### PR TITLE
fix: resolve lint and type check CI failures

### DIFF
--- a/src/owasp_agentic_scanner/ast_analyzer.py
+++ b/src/owasp_agentic_scanner/ast_analyzer.py
@@ -271,8 +271,8 @@ class PythonASTAnalyzer(ast.NodeVisitor):
             return self.imports.get(base_name, base_name)
         elif isinstance(node, ast.Attribute):
             # Method call: obj.method()
-            parts = []
-            current = node
+            parts: list[str] = []
+            current: ast.expr = node
             while isinstance(current, ast.Attribute):
                 parts.append(current.attr)
                 current = current.value
@@ -300,8 +300,8 @@ class PythonASTAnalyzer(ast.NodeVisitor):
             return node.id
         elif isinstance(node, ast.Attribute):
             # Build the full attribute chain
-            parts = []
-            current = node
+            parts: list[str] = []
+            current: ast.expr = node
             while isinstance(current, ast.Attribute):
                 parts.append(current.attr)
                 current = current.value
@@ -361,9 +361,9 @@ class ASTSecurityChecker:
             return []
 
         analyzer = PythonASTAnalyzer(file_path)
-        taint_sources, dangerous_calls = analyzer.analyze(source)
+        _taint_sources, dangerous_calls = analyzer.analyze(source)
 
-        findings = []
+        findings: list[dict[str, Any]] = []
         for call_node, line_num, severity in dangerous_calls:
             func_name = analyzer._get_function_name(call_node.func)
 
@@ -378,7 +378,7 @@ class ASTSecurityChecker:
             # Determine if arguments are tainted
             is_tainted = analyzer._has_tainted_args(call_node)
 
-            finding = {
+            finding: dict[str, Any] = {
                 "function": func_name,
                 "line_number": line_num,
                 "line_content": line_content,
@@ -418,17 +418,20 @@ class ASTSecurityChecker:
         analyzer = PythonASTAnalyzer(file_path)
         _, dangerous_calls = analyzer.analyze(source)
 
-        findings = []
-        for call_node, line_num, severity in dangerous_calls:
+        findings: list[dict[str, Any]] = []
+        for call_node, line_num, _severity in dangerous_calls:
             func_name = analyzer._get_function_name(call_node.func)
 
             if func_name.startswith("subprocess."):
                 # Check for shell=True with tainted input
                 shell_true = False
                 for keyword in call_node.keywords:
-                    if keyword.arg == "shell" and isinstance(keyword.value, ast.Constant):
-                        if keyword.value.value is True:
-                            shell_true = True
+                    if (
+                        keyword.arg == "shell"
+                        and isinstance(keyword.value, ast.Constant)
+                        and keyword.value.value is True
+                    ):
+                        shell_true = True
 
                 is_tainted = analyzer._has_tainted_args(call_node)
 

--- a/src/owasp_agentic_scanner/baseline.py
+++ b/src/owasp_agentic_scanner/baseline.py
@@ -49,7 +49,11 @@ class BaselineFinding:
 
     @staticmethod
     def _compute_hash(
-        rule_id: str, file_path: str, line_number: int, message: str, line_content: str
+        rule_id: str,
+        file_path: str,
+        line_number: int,  # noqa: ARG004
+        message: str,
+        line_content: str,
     ) -> str:
         """Compute a stable hash for a finding."""
         import hashlib
@@ -142,7 +146,7 @@ class Baseline:
         self.metadata = {
             "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
             "total_findings": len(findings),
-            "files_scanned": len(set(f.file_path for f in findings)),
+            "files_scanned": len({f.file_path for f in findings}),
         }
 
         data = {

--- a/src/owasp_agentic_scanner/cache.py
+++ b/src/owasp_agentic_scanner/cache.py
@@ -4,6 +4,7 @@ This enables scanning only changed files, making the scanner much faster
 for repeated runs and CI/CD usage.
 """
 
+import contextlib
 import fcntl
 import hashlib
 import json
@@ -32,11 +33,8 @@ class FileLock:
 
         if sys.platform != "win32":
             # Use fcntl on Unix-like systems
-            try:
+            with contextlib.suppress(OSError, AttributeError):
                 fcntl.flock(self.lock_fd.fileno(), fcntl.LOCK_EX)
-            except (OSError, AttributeError):
-                # fcntl not available or lock failed
-                pass
         # Note: Windows locking would require msvcrt, skipping for now
 
         return self
@@ -45,10 +43,8 @@ class FileLock:
         """Release lock."""
         if self.lock_fd:
             if sys.platform != "win32":
-                try:
+                with contextlib.suppress(OSError, AttributeError):
                     fcntl.flock(self.lock_fd.fileno(), fcntl.LOCK_UN)
-                except (OSError, AttributeError):
-                    pass
             self.lock_fd.close()
             self.lock_fd = None
 
@@ -116,9 +112,8 @@ class ScanCache:
         """Save cache to disk with file locking."""
         try:
             self.cache_dir.mkdir(parents=True, exist_ok=True)
-            with FileLock(self.lock_file):
-                with open(self.cache_file, "w", encoding="utf-8") as f:
-                    json.dump(self.cache_data, f, indent=2)
+            with FileLock(self.lock_file), open(self.cache_file, "w", encoding="utf-8") as f:
+                json.dump(self.cache_data, f, indent=2)
             logger.debug(f"Saved cache with {len(self.cache_data)} entries")
         except OSError as e:
             logger.warning(f"Failed to save cache: {e}")
@@ -168,7 +163,7 @@ class ScanCache:
 
         return cached_entry.get("hash") != current_hash
 
-    def update(self, file_path: Path, findings: list) -> None:
+    def update(self, file_path: Path, findings: list[Any]) -> None:
         """Update cache with new scan results.
 
         Args:
@@ -253,8 +248,8 @@ class ScanCache:
         Args:
             project_root: Root directory of the project
         """
-        deleted_keys = []
-        for file_key in self.cache_data.keys():
+        deleted_keys: list[str] = []
+        for file_key in self.cache_data:
             file_path = Path(file_key)
             if not file_path.exists() or not file_path.is_relative_to(project_root):
                 deleted_keys.append(file_key)

--- a/src/owasp_agentic_scanner/cli.py
+++ b/src/owasp_agentic_scanner/cli.py
@@ -259,7 +259,7 @@ def scan(
             cache_path_obj = Path(cache_dir).resolve(strict=False)
         except (OSError, ValueError) as e:
             console.print(f"[red]Error: Invalid cache directory: {e}[/red]")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from None
 
         # Explicitly block dangerous directories FIRST (resolve them too)
         dangerous_paths = [
@@ -283,7 +283,7 @@ def scan(
         allowed_bases = [
             Path.home(),  # User home directory
             Path.cwd(),  # Current working directory
-            Path("/tmp").resolve(strict=False),  # Temp directory
+            Path("/tmp").resolve(strict=False),  # noqa: S108  # nosec B108 - Temp directory
             Path(tempfile.gettempdir()).resolve(
                 strict=False
             ),  # System temp (may differ from /tmp on macOS)
@@ -405,8 +405,8 @@ def scan(
                 findings = scanner.scan(scan_path, parallel=parallel)
             # Manual filtering if needed
             if git_diff and files_to_scan:
-                files_to_scan_set = set(files_to_scan)
-                findings = [f for f in findings if f.file_path in files_to_scan_set]
+                files_to_scan_strs = {str(p) for p in files_to_scan}
+                findings = [f for f in findings if str(f.file_path) in files_to_scan_strs]
 
     if not use_optimized:
         # Use original scanner
@@ -422,8 +422,8 @@ def scan(
 
         # Manual filtering for old scanner
         if git_diff and files_to_scan:
-            files_to_scan_set = set(files_to_scan)
-            findings = [f for f in findings if f.file_path in files_to_scan_set]
+            files_to_scan_strs = {str(p) for p in files_to_scan}
+            findings = [f for f in findings if str(f.file_path) in files_to_scan_strs]
 
     # Apply baseline filtering if specified
     baseline = None
@@ -431,13 +431,16 @@ def scan(
         try:
             from owasp_agentic_scanner.baseline import Baseline
 
-            baseline = Baseline(Path(baseline_file))
-            if baseline.baseline_file.exists():
-                baseline.load()
-                new_findings, baselined_count = baseline.filter_new_findings(findings)
+            baseline_path = Path(baseline_file)
+            baseline = Baseline(baseline_path)
+            if baseline_path.exists():
+                baseline.load(baseline_path)
+                new_findings, baselined_findings = baseline.filter_new_findings(findings)
                 findings = new_findings
-                if format.lower() == "console" and baselined_count > 0:
-                    console.print(f"[dim]Filtered {baselined_count} baselined findings[/dim]")
+                if format.lower() == "console" and len(baselined_findings) > 0:
+                    console.print(
+                        f"[dim]Filtered {len(baselined_findings)} baselined findings[/dim]"
+                    )
         except ImportError:
             logger.warning("Baseline module not available")
         except Exception as e:
@@ -448,9 +451,9 @@ def scan(
         try:
             from owasp_agentic_scanner.baseline import Baseline
 
-            new_baseline = Baseline(Path(create_baseline))
-            new_baseline.create_from_findings(findings)
-            new_baseline.save()
+            new_baseline_path = Path(create_baseline)
+            new_baseline = Baseline()
+            new_baseline.save(new_baseline_path, findings)
             if format.lower() == "console":
                 console.print(
                     f"[green]Baseline created: {create_baseline} ({len(findings)} findings)[/green]"

--- a/src/owasp_agentic_scanner/config.py
+++ b/src/owasp_agentic_scanner/config.py
@@ -6,15 +6,12 @@ Allows users to configure scanner behavior via:
 - Environment variables
 """
 
+import contextlib
 import os
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-
-try:
-    import tomllib  # Python 3.11+
-except ImportError:
-    import tomli as tomllib  # type: ignore[import-not-found]
 
 
 @dataclass
@@ -193,10 +190,8 @@ class ScanConfig:
 
         # OWASP_SCAN_MAX_WORKERS=8
         if os.getenv("OWASP_SCAN_MAX_WORKERS"):
-            try:
+            with contextlib.suppress(ValueError):
                 self.max_workers = int(os.getenv("OWASP_SCAN_MAX_WORKERS", "0"))
-            except ValueError:
-                pass
 
         # OWASP_SCAN_MIN_SEVERITY=high
         if os.getenv("OWASP_SCAN_MIN_SEVERITY"):
@@ -243,7 +238,7 @@ class ScanConfig:
         """Save configuration to TOML file."""
         try:
             # We need tomli_w for writing
-            import tomli_w
+            import tomli_w  # type: ignore[import-not-found]
 
             with open(file_path, "wb") as f:
                 tomli_w.dump(self.to_dict(), f)

--- a/src/owasp_agentic_scanner/rules/code_execution_ast.py
+++ b/src/owasp_agentic_scanner/rules/code_execution_ast.py
@@ -4,7 +4,7 @@ import ast
 from pathlib import Path
 
 from owasp_agentic_scanner.ast_analyzer import ASTSecurityChecker
-from owasp_agentic_scanner.rules.base import Finding, Severity
+from owasp_agentic_scanner.rules.base import DetectionPattern, Finding, Severity
 from owasp_agentic_scanner.rules.base_ast import HybridRule
 from owasp_agentic_scanner.rules.code_execution import CodeExecutionRule
 
@@ -32,7 +32,7 @@ class CodeExecutionASTRule(HybridRule):
         self._pattern_rule = CodeExecutionRule()
         super().__init__()
 
-    def _get_patterns(self) -> list:
+    def _get_patterns(self) -> list[DetectionPattern]:
         """Get patterns for non-Python files."""
         if hasattr(self, "_pattern_rule"):
             return self._pattern_rule._get_patterns()
@@ -40,7 +40,7 @@ class CodeExecutionASTRule(HybridRule):
 
     def _scan_python_file(self, file_path: Path) -> list[Finding]:
         """Scan Python file using AST analysis."""
-        findings = []
+        findings: list[Finding] = []
 
         # Skip test files (different severity/context)
         if self._is_test_file(file_path):
@@ -165,7 +165,7 @@ class CodeExecutionASTRule(HybridRule):
 
     def _detect_llm_code_execution(self, file_path: Path) -> list[Finding]:
         """Detect patterns where LLM-generated code is executed."""
-        findings = []
+        findings: list[Finding] = []
 
         try:
             source = file_path.read_text(encoding="utf-8", errors="strict")
@@ -208,8 +208,8 @@ class CodeExecutionASTRule(HybridRule):
         if isinstance(node, ast.Name):
             return node.id
         elif isinstance(node, ast.Attribute):
-            parts = []
-            current = node
+            parts: list[str] = []
+            current: ast.expr = node
             while isinstance(current, ast.Attribute):
                 parts.append(current.attr)
                 current = current.value

--- a/src/owasp_agentic_scanner/rules/privilege_abuse.py
+++ b/src/owasp_agentic_scanner/rules/privilege_abuse.py
@@ -17,6 +17,7 @@ from owasp_agentic_scanner.constants import (
 from owasp_agentic_scanner.rules.base import (
     BaseRule,
     DetectionPattern,
+    Finding,
     Severity,
     pattern,
 )
@@ -51,14 +52,12 @@ def _has_placeholder_word(value: str) -> bool:
     value_lower = value.lower()
 
     for placeholder in placeholder_words:
-        if placeholder in value_lower:
-            # Check it's not just a substring of a longer identifier
-            if (
-                value_lower.startswith(placeholder)
-                or f"_{placeholder}" in value_lower
-                or placeholder.endswith("_")
-            ):
-                return True
+        if placeholder in value_lower and (
+            value_lower.startswith(placeholder)
+            or f"_{placeholder}" in value_lower
+            or placeholder.endswith("_")
+        ):
+            return True
     return False
 
 
@@ -130,10 +129,7 @@ def _is_placeholder_credential(value: str) -> bool:
         return True
 
     # Check for all same case (placeholders often all caps)
-    if value.isupper() and len(value) > MAX_UPPERCASE_PLACEHOLDER_LENGTH:
-        return True
-
-    return False
+    return value.isupper() and len(value) > MAX_UPPERCASE_PLACEHOLDER_LENGTH
 
 
 def _calculate_entropy(value: str) -> float:
@@ -197,10 +193,8 @@ def _is_likely_real_credential(value: str) -> bool:
 
     # Check entropy - real credentials have higher entropy
     entropy = _calculate_entropy(value)
-    if entropy < MIN_ENTROPY_THRESHOLD:  # Low entropy suggests pattern or repetition
-        return False
-
-    return True
+    # Low entropy suggests pattern or repetition
+    return entropy >= MIN_ENTROPY_THRESHOLD
 
 
 class PrivilegeAbuseRule(BaseRule):
@@ -281,7 +275,7 @@ class PrivilegeAbuseRule(BaseRule):
             ),
         ]
 
-    def scan_file(self, file_path: Path) -> list:
+    def scan_file(self, file_path: Path) -> list[Finding]:
         """Override scan_file to add credential validation.
 
         This method adds post-processing to filter out placeholder credentials

--- a/src/owasp_agentic_scanner/scanner.py
+++ b/src/owasp_agentic_scanner/scanner.py
@@ -62,9 +62,9 @@ class CircuitBreaker:
     failure_threshold: int = CIRCUIT_BREAKER_FAILURE_THRESHOLD
     timeout_seconds: int = CIRCUIT_BREAKER_TIMEOUT_SECONDS
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Initialize circuit breaker state."""
-        self.failures: deque = deque(maxlen=self.failure_threshold)
+        self.failures: deque[datetime] = deque(maxlen=self.failure_threshold)
         self.state = "closed"  # closed, open, half_open
 
     def record_failure(self) -> None:
@@ -204,15 +204,12 @@ class OptimizedScanner:
         Returns:
             List of all findings
         """
-        findings = []
+        findings: list[Finding] = []
 
         # Determine which files to scan
-        if files_to_scan is not None:
-            # Git-diff mode: only scan specified files
-            files_iter = iter(files_to_scan)
-        else:
-            # Normal mode: discover all files
-            files_iter = self.discover_files(path)
+        files_iter: Iterator[Path] = (
+            iter(files_to_scan) if files_to_scan is not None else self.discover_files(path)
+        )
 
         if not parallel:
             # Sequential scanning
@@ -247,7 +244,9 @@ class OptimizedScanner:
         """Scan in parallel with batched task submission (legacy method)."""
         return self._scan_parallel_with_cache(self.discover_files(path), cache=None)
 
-    def _scan_parallel_with_cache(self, files_iter, cache=None) -> list[Finding]:
+    def _scan_parallel_with_cache(
+        self, files_iter: Iterator[Path], cache: "ScanCache | None" = None
+    ) -> list[Finding]:
         """Scan in parallel with batched task submission and cache support.
 
         Args:
@@ -325,12 +324,12 @@ class OptimizedScanner:
             findings: List of findings from the batch
             cache: Cache instance to update
         """
-        from filelock import FileLock, Timeout
+        from filelock import FileLock, Timeout  # type: ignore[import-not-found]
 
         from owasp_agentic_scanner.constants import CACHE_LOCK_TIMEOUT_SECONDS
 
         # Group findings by file
-        findings_by_file = {}
+        findings_by_file: dict[Path, list[Finding]] = {}
         for finding in findings:
             file_path = Path(finding.file_path)
             if file_path not in findings_by_file:
@@ -356,7 +355,9 @@ class OptimizedScanner:
                 extra={"batch_size": len(tasks), "findings_count": len(findings)},
             )
 
-    def _cancel_remaining_futures(self, future_to_task: dict[Future, ScanTask]) -> None:
+    def _cancel_remaining_futures(
+        self, future_to_task: dict["Future[tuple[Path, list[Finding]]]", ScanTask]
+    ) -> None:
         """Cancel all remaining futures that haven't completed.
 
         Args:
@@ -368,8 +369,8 @@ class OptimizedScanner:
 
     def _handle_task_result(
         self,
-        future: Future[tuple[Path, list[Finding]]],
-        future_to_task: dict[Future, ScanTask],
+        future: "Future[tuple[Path, list[Finding]]]",
+        future_to_task: dict["Future[tuple[Path, list[Finding]]]", ScanTask],
         findings: list[Finding],
         circuit_breaker: CircuitBreaker,
         max_findings: int,
@@ -426,7 +427,7 @@ class OptimizedScanner:
         Implements circuit breaker pattern and memory limits to prevent
         resource exhaustion during parallel scanning.
         """
-        findings = []
+        findings: list[Finding] = []
         circuit_breaker = CircuitBreaker(
             failure_threshold=CIRCUIT_BREAKER_FAILURE_THRESHOLD,
             timeout_seconds=CIRCUIT_BREAKER_TIMEOUT_SECONDS,
@@ -525,7 +526,4 @@ class FileFilter:
 
         # Skip lockfiles
         lockfiles = {"package-lock.json", "yarn.lock", "poetry.lock", "Pipfile.lock"}
-        if file_path.name in lockfiles:
-            return True
-
-        return False
+        return file_path.name in lockfiles


### PR DESCRIPTION
## Summary

Fixes the failing CI workflows (Lint and Type Check) from PR #5.

### Changes

**Type Annotations:**
- Add proper type annotations for generic types (`list`, `dict`, `deque`, `Future`)
- Fix `ast.expr` type annotations in `ast_analyzer.py`
- Add missing imports for `Finding` and `DetectionPattern`

**Lint Fixes:**
- Use `contextlib.suppress` instead of `try-except-pass` (SIM105)
- Combine nested `if` statements (SIM102)
- Simplify return statements (SIM103)
- Use set comprehension instead of generator (C401)
- Remove `.keys()` from dict iteration (SIM118)
- Add `raise from None` for proper exception chaining (B904)

**API Fixes:**
- Fix `Baseline.load()` and `Baseline.save()` method signatures in CLI
- Fix file path type comparisons (str vs Path)

**Security:**
- Add `# nosec B108` for intentional `/tmp` usage
- Add `type: ignore[import-not-found]` for optional dependencies

## Test plan

- [x] `uv run ruff check src` passes
- [x] `uv run mypy src` passes
- [ ] CI Lint workflow passes
- [ ] CI Type Check workflow passes