### PR TITLE
fix: resolve remaining lint and type check CI failures

### DIFF
--- a/src/owasp_agentic_scanner/config.py
+++ b/src/owasp_agentic_scanner/config.py
@@ -238,7 +238,7 @@ class ScanConfig:
         """Save configuration to TOML file."""
         try:
             # We need tomli_w for writing
-            import tomli_w  # type: ignore[import-not-found]
+            import tomli_w
 
             with open(file_path, "wb") as f:
                 tomli_w.dump(self.to_dict(), f)

--- a/src/owasp_agentic_scanner/scanner.py
+++ b/src/owasp_agentic_scanner/scanner.py
@@ -324,7 +324,7 @@ class OptimizedScanner:
             findings: List of findings from the batch
             cache: Cache instance to update
         """
-        from filelock import FileLock, Timeout  # type: ignore[import-not-found]
+        from filelock import FileLock, Timeout
 
         from owasp_agentic_scanner.constants import CACHE_LOCK_TIMEOUT_SECONDS
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -40,7 +40,7 @@ class TestScanCommand:
         test_file.write_text("eval(input())")
         output_file = tmp_path / "results.json"
 
-        result = runner.invoke(
+        runner.invoke(
             app, ["scan", str(test_file), "--format", "json", "--output", str(output_file)]
         )
 
@@ -55,7 +55,7 @@ class TestScanCommand:
         test_file.write_text("eval(input())")
         output_file = tmp_path / "results.sarif"
 
-        result = runner.invoke(
+        runner.invoke(
             app, ["scan", str(test_file), "--format", "sarif", "--output", str(output_file)]
         )
 
@@ -532,7 +532,7 @@ class TestCLIEdgeCases:
         assert result.exit_code == 0
 
         # Temp directory - should work
-        cache_in_tmp = Path("/tmp") / ".test_cache"
+        cache_in_tmp = Path("/tmp") / ".test_cache"  # noqa: S108
         result = runner.invoke(
             app, ["scan", str(tmp_path), "--cache", "--cache-dir", str(cache_in_tmp)]
         )

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -146,7 +146,7 @@ class TestBaselineIntegration:
 
         # Filter - fuzzy matching should still match
         baseline2 = Baseline(baseline_file)
-        new_findings, baselined = baseline2.filter_new_findings(findings2)
+        _new_findings, baselined = baseline2.filter_new_findings(findings2)
 
         # Should still be baselined despite line number shift
         assert len(baselined) > 0
@@ -216,7 +216,7 @@ class TestMultiModuleIntegration:
 
         # Filter with baseline
         baseline2 = Baseline(baseline_file)
-        new_findings, baselined = baseline2.filter_new_findings(findings2)
+        new_findings, _baselined = baseline2.filter_new_findings(findings2)
 
         # test.py should be cached and baselined
         # test2.py should be new

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -174,7 +174,7 @@ result = func(user_input)
 
         # Note: Current implementation may not catch this advanced case
         # This test documents a limitation
-        findings = ASTSecurityChecker.check_dangerous_functions(test_file)
+        ASTSecurityChecker.check_dangerous_functions(test_file)
         # This is a known limitation - advanced obfuscation may not be detected
 
     def test_f_string_taint(self, tmp_path: Path) -> None:

--- a/tests/unit/test_privilege_abuse_helpers.py
+++ b/tests/unit/test_privilege_abuse_helpers.py
@@ -9,23 +9,23 @@ def test_placeholder_detection():
     from owasp_agentic_scanner.rules.privilege_abuse import _is_placeholder_credential
 
     # These should be identified as placeholders
-    assert _is_placeholder_credential("YOUR_API_KEY_HERE") == True
-    assert _is_placeholder_credential("example_password") == True
-    assert _is_placeholder_credential("xxxxxxxxxxxxxxxx") == True
-    assert _is_placeholder_credential("12345678") == True
-    assert _is_placeholder_credential("password123") == True
-    assert _is_placeholder_credential("PLACEHOLDER_TOKEN") == True
-    assert _is_placeholder_credential("changeme") == True
-    assert _is_placeholder_credential("put_your_key_here") == True
-    assert _is_placeholder_credential("test") == True
-    assert _is_placeholder_credential("fake") == True
-    assert _is_placeholder_credential("xxx") == True
-    assert _is_placeholder_credential("qwertyqwerty") == True
-    assert _is_placeholder_credential("ALLUPPERCASEPLACEHOLDER") == True
+    assert _is_placeholder_credential("YOUR_API_KEY_HERE")
+    assert _is_placeholder_credential("example_password")
+    assert _is_placeholder_credential("xxxxxxxxxxxxxxxx")
+    assert _is_placeholder_credential("12345678")
+    assert _is_placeholder_credential("password123")
+    assert _is_placeholder_credential("PLACEHOLDER_TOKEN")
+    assert _is_placeholder_credential("changeme")
+    assert _is_placeholder_credential("put_your_key_here")
+    assert _is_placeholder_credential("test")
+    assert _is_placeholder_credential("fake")
+    assert _is_placeholder_credential("xxx")
+    assert _is_placeholder_credential("qwertyqwerty")
+    assert _is_placeholder_credential("ALLUPPERCASEPLACEHOLDER")
 
     # These should NOT be placeholders
-    assert _is_placeholder_credential("sk_live_51HqT2P...") == False
-    assert _is_placeholder_credential("ghp_1s3K4r3T...") == False
+    assert not _is_placeholder_credential("sk_live_51HqT2P...")
+    assert not _is_placeholder_credential("ghp_1s3K4r3T...")
 
 
 def test_entropy_calculation():
@@ -52,25 +52,25 @@ def test_sequential_numbers():
     from owasp_agentic_scanner.rules.privilege_abuse import _is_sequential_numbers
 
     # Sequential ascending
-    assert _is_sequential_numbers("12345678") == True
-    assert _is_sequential_numbers("23456789") == True
+    assert _is_sequential_numbers("12345678")
+    assert _is_sequential_numbers("23456789")
 
     # Sequential descending
-    assert _is_sequential_numbers("87654321") == True
+    assert _is_sequential_numbers("87654321")
 
     # Sequential with wrapping (9->0)
-    assert _is_sequential_numbers("89012345") == True
+    assert _is_sequential_numbers("89012345")
 
     # Not sequential - all same digit (edge case fix)
-    assert _is_sequential_numbers("00000000") == False
-    assert _is_sequential_numbers("11111111") == False
-    assert _is_sequential_numbers("99999999") == False
+    assert not _is_sequential_numbers("00000000")
+    assert not _is_sequential_numbers("11111111")
+    assert not _is_sequential_numbers("99999999")
 
     # Not sequential - other cases
-    assert _is_sequential_numbers("12346789") == False  # Skip
-    assert _is_sequential_numbers("abc12345") == False  # Not digits
-    assert _is_sequential_numbers("1234567") == False  # Too short
-    assert _is_sequential_numbers("13579246") == False  # Random
+    assert not _is_sequential_numbers("12346789")  # Skip
+    assert not _is_sequential_numbers("abc12345")  # Not digits
+    assert not _is_sequential_numbers("1234567")  # Too short
+    assert not _is_sequential_numbers("13579246")  # Random
 
 
 def test_real_credential_detection():
@@ -78,16 +78,16 @@ def test_real_credential_detection():
     from owasp_agentic_scanner.rules.privilege_abuse import _is_likely_real_credential
 
     # Real-looking credentials
-    assert _is_likely_real_credential("sk_live_51HqT2P2KCm") == True
-    assert _is_likely_real_credential("ghp_1s3K4r3Tm0nk3y") == True
-    assert _is_likely_real_credential("AIzaSyC-JlK7jkLm9nO0pQrS") == True
+    assert _is_likely_real_credential("sk_live_51HqT2P2KCm")
+    assert _is_likely_real_credential("ghp_1s3K4r3Tm0nk3y")
+    assert _is_likely_real_credential("AIzaSyC-JlK7jkLm9nO0pQrS")
 
     # Placeholders
-    assert _is_likely_real_credential("YOUR_API_KEY") == False
-    assert _is_likely_real_credential("example_password") == False
-    assert _is_likely_real_credential("xxxxxxxxxxxx") == False
-    assert _is_likely_real_credential("12345678") == False
-    assert _is_likely_real_credential("password") == False
+    assert not _is_likely_real_credential("YOUR_API_KEY")
+    assert not _is_likely_real_credential("example_password")
+    assert not _is_likely_real_credential("xxxxxxxxxxxx")
+    assert not _is_likely_real_credential("12345678")
+    assert not _is_likely_real_credential("password")
 
 
 def test_privilege_abuse_filters_placeholders():

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -119,7 +119,7 @@ class TestOptimizedScanner:
 
         rules = [CodeExecutionRule(), GoalHijackRule()]
         scanner = OptimizedScanner(rules=rules)
-        findings = scanner.scan(tmp_path, parallel=False)
+        scanner.scan(tmp_path, parallel=False)
 
         # Should work with multiple rules
         assert scanner.rules == rules
@@ -206,7 +206,7 @@ class TestOptimizedScanner:
         scanner = OptimizedScanner(rules=[rule])
 
         # First scan
-        findings1 = scanner.scan(tmp_path, parallel=False, cache=cache)
+        scanner.scan(tmp_path, parallel=False, cache=cache)
         cache.save()
 
         # Verify cache was populated


### PR DESCRIPTION
## Summary

Fixes the remaining CI failures from PR #6.

### Changes

**Type Check Fixes:**
- Remove unused `type: ignore[import-not-found]` comments (deps are installed in CI)

**Lint Fixes in Tests:**
- Fix E712: Use `assert x` instead of `assert x == True`
- Fix F841: Remove unused variable assignments
- Fix RUF059: Prefix unused unpacked variables with underscore
- Add `noqa: S108` for intentional `/tmp` usage in test

## Test plan

- [x] `uv run ruff check src tests` passes
- [x] `uv run mypy src` passes
- [ ] CI Lint workflow passes
- [ ] CI Type Check workflow passes