### PR TITLE
fix: update pre-commit config for CI compatibility

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,4 @@ jobs:
         run: uv run ruff format --check src tests
 
       - name: Run pre-commit hooks
-        run: uv run pre-commit run --all-files
+        run: SKIP=no-commit-to-branch uv run pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,8 @@ repos:
         additional_dependencies:
           - typer>=0.12.0
           - rich>=13.7.0
+          - tomli_w>=1.0.0
+          - filelock>=3.0.0
         pass_filenames: false
         entry: mypy src
 
@@ -40,7 +42,7 @@ repos:
       - id: bandit
         args: [-ll, -c, pyproject.toml]
         additional_dependencies: [".[toml]"]
-        exclude: ^tests/
+        exclude: ^(tests/|examples/)
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.0


### PR DESCRIPTION
## Summary

Fixes the remaining pre-commit hook failures in CI.

### Changes

1. **mypy additional_dependencies**: Added `tomli_w` and `filelock` so mypy can type-check the optional imports
2. **bandit exclude**: Added `examples/` to exclusions since it contains intentional vulnerabilities for testing
3. **no-commit-to-branch**: Skip this hook in CI since it runs on main after merge

## Test plan

- [ ] CI Lint workflow passes (all pre-commit hooks)
- [ ] CI Type Check workflow passes
- [ ] CI Test workflow passes
- [ ] CI Security Scan workflow passes