### PR TITLE
docs: minimal README, move content to dedicated docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,100 +1,41 @@
-# Contributing to OWASP Agentic AI Scanner
+# Contributing
 
-Thank you for your interest in contributing!
-
-## Getting Started
-
-### 1. Fork the Repository
-
-1. Go to [https://github.com/NP-compete/owasp-agentic-scanner](https://github.com/NP-compete/owasp-agentic-scanner)
-2. Click the "Fork" button in the top right
-3. This creates a copy in your GitHub account
-
-### 2. Clone Your Fork
+## Development Setup
 
 ```bash
-git clone https://github.com/YOUR-USERNAME/owasp-agentic-scanner.git
+git clone https://github.com/NP-compete/owasp-agentic-scanner.git
 cd owasp-agentic-scanner
-```
-
-### 3. Add Upstream Remote
-
-```bash
-git remote add upstream https://github.com/NP-compete/owasp-agentic-scanner.git
-git remote -v  # Verify you have both origin (your fork) and upstream (original repo)
-```
-
-### 4. Install Development Dependencies
-
-```bash
 make install-dev
 ```
 
-## Development Workflow
-
-### 1. Sync Your Fork
-
-Before creating a new branch, sync with the latest changes:
+## Running Checks
 
 ```bash
-git checkout main
-git fetch upstream
-git merge upstream/main
-git push origin main  # Update your fork
+make pre-commit  # Run all checks (lint, format, test)
+make test        # Run tests only
+make lint        # Run linting only
 ```
 
-### 2. Create a Feature Branch
+## Workflow
 
-```bash
-git checkout -b feature/your-feature-name
-```
-
-### 3. Make Your Changes
-
-- Write code following our code standards (see below)
-- Add tests for new features
-- Update documentation if needed
-
-### 4. Run Checks
-
-```bash
-make pre-commit  # Runs linting, formatting, and tests
-```
-
-### 5. Commit Your Changes
-
-```bash
-git add .
-git commit -m "feat: Add your feature description"
-```
-
-We follow [Conventional Commits](https://www.conventionalcommits.org/):
-- `feat:` - New feature
-- `fix:` - Bug fix
-- `docs:` - Documentation changes
-- `test:` - Test changes
-- `refactor:` - Code refactoring
-
-### 6. Push to Your Fork
-
-```bash
-git push origin feature/your-feature-name
-```
-
-### 7. Submit a Pull Request
-
-1. Go to your fork on GitHub
-2. Click "Pull Request" button
-3. Select your feature branch
-4. Fill out the PR template
-5. Submit the PR
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/your-feature`
+3. Make changes and add tests
+4. Run checks: `make pre-commit`
+5. Commit using [Conventional Commits](https://www.conventionalcommits.org/):
+   - `feat:` - New feature
+   - `fix:` - Bug fix
+   - `docs:` - Documentation
+   - `test:` - Tests
+   - `refactor:` - Refactoring
+6. Push and open a Pull Request
 
 ## Code Standards
 
 - Python 3.11+
 - Type hints required
 - Ruff for linting/formatting
-- 85% test coverage minimum
+- 80% test coverage minimum
 
 ## Adding a New Rule
 
@@ -125,12 +66,12 @@ class YourRule(BaseRule):
         ]
 ```
 
-## PR Requirements
+## PR Checklist
 
-- [ ] All checks pass (`make pre-commit`)
+- [ ] `make pre-commit` passes
 - [ ] Tests added for new features
 - [ ] Documentation updated if needed
 
-## Questions?
+## Questions
 
-Open an issue or discussion.
+Open an issue or start a discussion.

--- a/README.md
+++ b/README.md
@@ -1,283 +1,66 @@
-<p align="center">
-  <img src="https://img.shields.io/badge/OWASP-Top%2010%20Agentic%20AI-blue?style=for-the-badge&logo=owasp" alt="OWASP Top 10 Agentic AI">
-</p>
+# OWASP Agentic AI Scanner
 
-<h1 align="center">🛡️ OWASP Agentic AI Scanner</h1>
+[![Lint](https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/lint.yml/badge.svg)](https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/lint.yml)
+[![Test](https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/test.yml/badge.svg)](https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/test.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-<p align="center">
-  <strong>Static analysis tool for detecting security risks from the OWASP Top 10 for Agentic AI Applications</strong>
-</p>
+Static analysis tool for detecting security risks from the [OWASP Top 10 for Agentic AI Applications](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/).
 
-<p align="center">
-  <a href="https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/lint.yml"><img src="https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/lint.yml/badge.svg" alt="Lint"></a>
-  <a href="https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/test.yml"><img src="https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/test.yml/badge.svg" alt="Test"></a>
-  <a href="https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/security.yml"><img src="https://github.com/NP-compete/owasp-agentic-scanner/actions/workflows/security.yml/badge.svg" alt="Security"></a>
-  <br>
-  <a href="https://pypi.org/project/owasp-agentic-scanner/"><img src="https://img.shields.io/pypi/v/owasp-agentic-scanner?color=blue" alt="PyPI"></a>
-  <a href="https://pypi.org/project/owasp-agentic-scanner/"><img src="https://img.shields.io/pypi/pyversions/owasp-agentic-scanner" alt="Python Versions"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>
-  <a href="https://github.com/NP-compete/owasp-agentic-scanner/stargazers"><img src="https://img.shields.io/github/stars/NP-compete/owasp-agentic-scanner?style=social" alt="Stars"></a>
-</p>
-
-<p align="center">
-  <a href="#-quick-start">Quick Start</a> •
-  <a href="#-features">Features</a> •
-  <a href="#-owasp-top-10-coverage">OWASP Coverage</a> •
-  <a href="#-usage">Usage</a> •
-  <a href="#-cicd-integration">CI/CD</a> •
-  <a href="#-contributing">Contributing</a>
-</p>
-
----
-
-## ✨ Features
-
-- 🔍 **All 10 OWASP Agentic AI risks** covered with 100+ detection patterns
-- 🌳 **AST-based analysis** for accurate Python code scanning
-- 🔄 **Taint tracking** for data flow analysis
-- 📊 **Multiple output formats**: Console, JSON, SARIF
-- ⚡ **Parallel scanning** for large codebases
-- 💾 **Incremental scanning** with smart caching
-- 🎯 **Baseline management** for tracking known issues
-- 🔗 **Git integration** for scanning only changed files
-- 🪝 **Pre-commit hook** for shift-left security
-
-## 🚀 Quick Start
+## Installation
 
 ```bash
-# Install from PyPI
 pip install owasp-agentic-scanner
-
-# Or install from source
-git clone https://github.com/NP-compete/owasp-agentic-scanner.git
-cd owasp-agentic-scanner
-uv sync
-
-# Scan your AI agent code
-owasp-scan scan /path/to/your/agent
-
-# Generate SARIF report for CI/CD
-owasp-scan scan src --format sarif --output results.sarif
 ```
 
-## 🎯 OWASP Top 10 Coverage
-
-| ID | Risk | Description |
-|----|------|-------------|
-| **AA01** | Agent Goal Hijack | Prompt injection, system prompt manipulation |
-| **AA02** | Tool Misuse & Exploitation | Unsafe shell commands, SQL injection |
-| **AA03** | Identity & Privilege Abuse | Hardcoded credentials, privilege escalation |
-| **AA04** | Agentic Supply Chain | Unsafe model loading, trust_remote_code |
-| **AA05** | Unexpected Code Execution | eval(), exec(), dynamic code execution |
-| **AA06** | Memory Poisoning | Vector store injection, RAG poisoning |
-| **AA07** | Excessive Agency | Missing human-in-the-loop, auto-approval |
-| **AA08** | Insecure Plugin Design | CORS misconfiguration, unsafe plugins |
-| **AA09** | Overreliance on Outputs | Disabled validation, unchecked outputs |
-| **AA10** | Model Theft | Missing rate limits, debug mode exposure |
-
-## 📖 Usage
-
-### Basic Scanning
+## Usage
 
 ```bash
 # Scan a directory
 owasp-scan scan src/
 
-# Scan with specific rules
-owasp-scan scan src --rules goal_hijack,code_execution
-
 # Filter by severity
 owasp-scan scan src --min-severity high
 
-# List all available rules
+# Output as SARIF (for CI/CD)
+owasp-scan scan src --format sarif --output results.sarif
+
+# List available rules
 owasp-scan list-rules
 ```
 
-### Output Formats
+## OWASP Top 10 Coverage
 
-```bash
-# Console output (default)
-owasp-scan scan src
+| ID | Risk |
+|----|------|
+| AA01 | Agent Goal Hijack |
+| AA02 | Tool Misuse & Exploitation |
+| AA03 | Identity & Privilege Abuse |
+| AA04 | Agentic Supply Chain |
+| AA05 | Unexpected Code Execution |
+| AA06 | Memory Poisoning |
+| AA07 | Excessive Agency |
+| AA08 | Insecure Plugin Design |
+| AA09 | Overreliance on Outputs |
+| AA10 | Model Theft |
 
-# JSON output
-owasp-scan scan src --format json --output results.json
-
-# SARIF output (for GitHub Code Scanning)
-owasp-scan scan src --format sarif --output results.sarif
-```
-
-### Advanced Features
-
-```bash
-# Parallel scanning (faster for large codebases)
-owasp-scan scan src --parallel --workers 8
-
-# Incremental scanning with cache
-owasp-scan scan src --cache --cache-dir .owasp-cache
-
-# Scan only git-changed files
-owasp-scan scan src --git-diff main
-
-# Use baseline to track known issues
-owasp-scan scan src --baseline .owasp-baseline.json
-```
-
-### Inline Suppression
-
-Suppress specific findings in your code:
+## Inline Suppression
 
 ```python
-# Suppress a specific rule
 eval(expression)  # noqa: AA05
-
-# Suppress all rules on a line
-exec(code)  # noqa: owasp-scan
-
-# Suppress multiple rules
-dangerous_call()  # noqa: AA02,AA05
 ```
 
-## 🔗 CI/CD Integration
+## Documentation
 
-### GitHub Actions
-
-```yaml
-name: Security Scan
-
-on: [push, pull_request]
-
-jobs:
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install scanner
-        run: pip install owasp-agentic-scanner
-
-      - name: Run OWASP scan
-        run: owasp-scan scan src --format sarif --output results.sarif
-
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-```
-
-### GitLab CI
-
-```yaml
-security-scan:
-  image: python:3.12
-  script:
-    - pip install owasp-agentic-scanner
-    - owasp-scan scan src --format json --output gl-sast-report.json
-  artifacts:
-    reports:
-      sast: gl-sast-report.json
-```
-
-### Pre-commit Hook
-
-Add to your `.pre-commit-config.yaml`:
-
-```yaml
-repos:
-  - repo: https://github.com/NP-compete/owasp-agentic-scanner
-    rev: v0.1.0
-    hooks:
-      - id: owasp-agentic-scan
-        args: [--min-severity, high]
-```
-
-## ⚙️ Configuration
-
-Create `.owasp-scan.toml` in your project root:
-
-```toml
-[rules]
-enabled = ["goal_hijack", "code_execution", "privilege_abuse"]
-disabled = []
-
-[scanning]
-parallel = true
-max_workers = 4
-max_file_size = 1048576  # 1MB
-
-[output]
-format = "console"
-verbose = true
-min_severity = "medium"
-
-[paths]
-exclude = ["tests/", "docs/", "*.test.py"]
-```
-
-## 🧪 Test Coverage
-
-| Component | Coverage | Tests |
-|-----------|----------|-------|
-| OWASP Rules | 100% | 21 |
-| Baseline System | 96% | 20 |
-| Config System | 90% | 22 |
-| Scanner Engine | 89% | 37 |
-| Cache System | 83% | 38 |
-| **Total** | **80%** | **294** |
-
-## 🛠️ Development
-
-```bash
-# Clone the repository
-git clone https://github.com/NP-compete/owasp-agentic-scanner.git
-cd owasp-agentic-scanner
-
-# Install development dependencies
-make install-dev
-
-# Run all checks
-make pre-commit
-
-# Run tests only
-make test
-
-# Run linting only
-make lint
-```
-
-## 🤝 Contributing
-
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run checks (`make pre-commit`)
-5. Commit (`git commit -m 'feat: Add amazing feature'`)
-6. Push (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
-
-## 📚 Documentation
-
-- [Architecture Overview](docs/ARCHITECTURE.md)
+- [Usage Guide](docs/USAGE.md)
+- [CI/CD Integration](docs/CICD.md)
+- [Configuration](docs/CONFIG.md)
 - [Detection Rules](docs/RULES.md)
-- [Extending the Scanner](docs/EXTENDING.md)
-- [Pre-commit Integration](docs/PRE_COMMIT.md)
+- [Architecture](docs/ARCHITECTURE.md)
 
-## 🔒 Security
+## Contributing
 
-For security vulnerabilities, please see [SECURITY.md](SECURITY.md) or use GitHub's private vulnerability reporting.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## 📄 License
+## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🙏 Acknowledgments
-
-- [OWASP GenAI Security Project](https://genai.owasp.org/)
-- [OWASP Top 10 for Agentic Applications](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
-
----
-
-<p align="center">
-  Made with ❤️ for the AI security community
-</p>
+MIT - see [LICENSE](LICENSE).

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -1,0 +1,78 @@
+# CI/CD Integration
+
+## GitHub Actions
+
+```yaml
+name: Security Scan
+
+on: [push, pull_request]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install scanner
+        run: pip install owasp-agentic-scanner
+
+      - name: Run OWASP scan
+        run: owasp-scan scan src --format sarif --output results.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
+
+## GitLab CI
+
+```yaml
+security-scan:
+  image: python:3.12
+  script:
+    - pip install owasp-agentic-scanner
+    - owasp-scan scan src --format json --output gl-sast-report.json
+  artifacts:
+    reports:
+      sast: gl-sast-report.json
+```
+
+## Azure DevOps
+
+```yaml
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.12'
+
+- script: |
+    pip install owasp-agentic-scanner
+    owasp-scan scan src --format sarif --output $(Build.ArtifactStagingDirectory)/results.sarif
+  displayName: 'Run OWASP Scan'
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: $(Build.ArtifactStagingDirectory)/results.sarif
+    artifactName: security-results
+```
+
+## Jenkins
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('Security Scan') {
+            steps {
+                sh 'pip install owasp-agentic-scanner'
+                sh 'owasp-scan scan src --format json --output results.json'
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'results.json'
+                }
+            }
+        }
+    }
+}
+```

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,48 @@
+# Configuration
+
+## Configuration File
+
+Create `.owasp-scan.toml` in your project root:
+
+```toml
+[rules]
+enabled = ["goal_hijack", "code_execution", "privilege_abuse"]
+disabled = []
+
+[scanning]
+parallel = true
+max_workers = 4
+max_file_size = 1048576  # 1MB
+
+[output]
+format = "console"
+verbose = true
+min_severity = "medium"
+
+[paths]
+exclude = ["tests/", "docs/", "*.test.py"]
+```
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OWASP_SCAN_PARALLEL` | Enable parallel scanning | `false` |
+| `OWASP_SCAN_MAX_WORKERS` | Number of parallel workers | `4` |
+| `OWASP_SCAN_MIN_SEVERITY` | Minimum severity to report | `low` |
+| `OWASP_SCAN_FORMAT` | Output format | `console` |
+
+## Configuration Priority
+
+1. CLI arguments (highest)
+2. Environment variables
+3. `.owasp-scan.toml` in current directory
+4. `pyproject.toml` `[tool.owasp-scan]` section
+5. Default values (lowest)
+
+## Severity Levels
+
+- `critical` - Immediate security risk
+- `high` - Significant security concern
+- `medium` - Potential security issue
+- `low` - Informational finding

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,74 @@
+# Usage Guide
+
+## Basic Scanning
+
+```bash
+# Scan a directory
+owasp-scan scan src/
+
+# Scan with specific rules
+owasp-scan scan src --rules goal_hijack,code_execution
+
+# Filter by severity
+owasp-scan scan src --min-severity high
+
+# List all available rules
+owasp-scan list-rules
+```
+
+## Output Formats
+
+```bash
+# Console output (default)
+owasp-scan scan src
+
+# JSON output
+owasp-scan scan src --format json --output results.json
+
+# SARIF output (for GitHub Code Scanning)
+owasp-scan scan src --format sarif --output results.sarif
+```
+
+## Advanced Features
+
+```bash
+# Parallel scanning (faster for large codebases)
+owasp-scan scan src --parallel --workers 8
+
+# Incremental scanning with cache
+owasp-scan scan src --cache --cache-dir .owasp-cache
+
+# Scan only git-changed files
+owasp-scan scan src --git-diff main
+
+# Use baseline to track known issues
+owasp-scan scan src --baseline .owasp-baseline.json
+```
+
+## Inline Suppression
+
+Suppress specific findings in your code:
+
+```python
+# Suppress a specific rule
+eval(expression)  # noqa: AA05
+
+# Suppress all rules on a line
+exec(code)  # noqa: owasp-scan
+
+# Suppress multiple rules
+dangerous_call()  # noqa: AA02,AA05
+```
+
+## Pre-commit Hook
+
+Add to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/NP-compete/owasp-agentic-scanner
+    rev: v0.1.0
+    hooks:
+      - id: owasp-agentic-scan
+        args: [--min-severity, high]
+```


### PR DESCRIPTION
## Summary

Simplifies README to essentials and moves detailed content to dedicated documentation files.

## Changes

**README.md** - Now contains only:
- Badges (CI status, license)
- One-line description
- Installation command
- Basic usage examples
- OWASP Top 10 table
- Links to documentation

**New docs/**:
- `USAGE.md` - Detailed usage guide, output formats, advanced features, pre-commit
- `CICD.md` - GitHub Actions, GitLab CI, Azure DevOps, Jenkins examples
- `CONFIG.md` - Configuration file format, environment variables, priority

**CONTRIBUTING.md** - Added development setup section

## Result

README went from 284 lines to 67 lines.