### PR TITLE
fix: update informationUri to correct repository URL

### DIFF
--- a/src/owasp_agentic_scanner/reporters/sarif_reporter.py
+++ b/src/owasp_agentic_scanner/reporters/sarif_reporter.py
@@ -47,7 +47,7 @@ class SarifReporter:
                         "driver": {
                             "name": "OWASP Agentic AI Scanner",
                             "version": "0.1.0",
-                            "informationUri": "https://github.com/NP-compete/owasp-agentic-ai-security-scanner",
+                            "informationUri": "https://github.com/NP-compete/owasp-agentic-scanner",
                             "rules": rules,
                         }
                     },


### PR DESCRIPTION
Closes #2

Updated informationUri in sarif_reporter.py from the old repository URL 
to the correct one:

Before: https://github.com/NP-compete/owasp-agentic-ai-security-scanner
After: https://github.com/NP-compete/owasp-agentic-scanner
