### PR TITLE
fix inline suppression for optimized scanner

### DIFF
--- a/src/owasp_agentic_scanner/cli.py
+++ b/src/owasp_agentic_scanner/cli.py
@@ -405,6 +405,8 @@ def scan(
                     findings = scanner.scan(scan_path, parallel=parallel)
             else:
                 findings = scanner.scan(scan_path, parallel=parallel)
+            # Filter suppressed findings
+            findings = filter_suppressed(findings)
             # Manual filtering if needed
             if git_diff and files_to_scan:
                 files_to_scan_strs = {str(p) for p in files_to_scan}

--- a/src/owasp_agentic_scanner/cli.py
+++ b/src/owasp_agentic_scanner/cli.py
@@ -392,6 +392,8 @@ def scan(
                 findings = scanner.scan(
                     scan_path, parallel=parallel, files_to_scan=files_to_scan, cache=cache
                 )
+            # Filter suppressed findings from optimized scanner
+            findings = filter_suppressed(findings)
         except ImportError:
             logger.warning("Optimized scanner not available, using standard scanner")
             use_optimized = False


### PR DESCRIPTION
hey, saw the issue about # noqa not working with the optimized scanner. turns out filter_suppressed() was only called in the legacy path but not after OptimizedScanner.scan().

added the filter call to both optimized paths (the main one and the typeerror fallback). tested locally and # noqa: AA05 works now.

let me know if you need anything else!