### PR TITLE
fix: update sarif repo url

### DIFF
--- a/src/owasp_agentic_scanner/reporters/sarif_reporter.py
+++ b/src/owasp_agentic_scanner/reporters/sarif_reporter.py
@@ -47,7 +47,7 @@ class SarifReporter:
                         "driver": {
                             "name": "OWASP Agentic AI Scanner",
                             "version": "0.1.0",
-                            "informationUri": "https://github.com/NP-compete/owasp-agentic-ai-security-scanner",
+                            "informationUri": "https://github.com/NP-compete/owasp-agentic-scanner",
                             "rules": rules,
                         }
                     },

--- a/src/owasp_agentic_scanner/reporters/sarif_reporter.py
+++ b/src/owasp_agentic_scanner/reporters/sarif_reporter.py
@@ -1,7 +1,8 @@
 """SARIF reporter for scan results.
 
 SARIF (Static Analysis Results Interchange Format) is a standard format
-for static analysis tools, enabling integration with CI/CD systems.
+for static analysis tools, enabling integration with CI/CD systems and
+GitHub Code Scanning.
 """
 
 import json


### PR DESCRIPTION
noticed the sarif reporter was using the old repo url. updated it to point to the correct repo now.

also updated the docstring to mention github code scanning since that's what sarif is mainly used for.

pretty straightforward change, let me know if anything else needs updating!