### PR TITLE
add filelock as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "rich>=13.7.0",
     "typer>=0.12.0",
-    "tomli>=2.0.1; python_version < '3.11'",
+    "filelock>=3.0.0",
     "tomli-w>=1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "rich>=13.7.0",
-    "typer>=0.12.0",
     "filelock>=3.0.0",
+    "rich>=13.7.0",
     "tomli-w>=1.0.0",
+    "typer>=0.12.0",
 ]
 
 [project.optional-dependencies]

--- a/src/owasp_agentic_scanner/reporters/sarif_reporter.py
+++ b/src/owasp_agentic_scanner/reporters/sarif_reporter.py
@@ -47,7 +47,7 @@ class SarifReporter:
                         "driver": {
                             "name": "OWASP Agentic AI Scanner",
                             "version": "0.1.0",
-                            "informationUri": "https://github.com/NP-compete/owasp-agentic-ai-security-scanner",
+                            "informationUri": "https://github.com/NP-compete/owasp-agentic-scanner",
                             "rules": rules,
                         }
                     },

--- a/src/owasp_agentic_scanner/reporters/sarif_reporter.py
+++ b/src/owasp_agentic_scanner/reporters/sarif_reporter.py
@@ -1,7 +1,8 @@
 """SARIF reporter for scan results.
 
 SARIF (Static Analysis Results Interchange Format) is a standard format
-for static analysis tools, enabling integration with CI/CD systems.
+for static analysis tools, enabling integration with CI/CD systems and
+GitHub Code Scanning.
 """
 
 import json


### PR DESCRIPTION
noticed filelock was being used in scanner.py and cache.py but wasn't listed as a dependency. added it to pyproject.toml so it's not just a transitive dependency anymore.

also removed the tomli dependency since requires-python is >=3.11, so that conditional was never gonna install anyway.

sorted the dependencies alphabetically while i was there. let me know if anything looks off!