### PR TITLE
fix: correct path resolution in prune deleted files

### DIFF
--- a/src/owasp_agentic_scanner/cache.py
+++ b/src/owasp_agentic_scanner/cache.py
@@ -250,7 +250,7 @@ class ScanCache:
         """
         deleted_keys: list[str] = []
         for file_key in self.cache_data:
-            file_path = Path(file_key)
+            file_path = project_root / file_key
             if not file_path.exists() or not file_path.is_relative_to(project_root):
                 deleted_keys.append(file_key)
 


### PR DESCRIPTION
## Summary
This PR fixes a bug in `cache.py` where `prune_deleted_files` was incorrectly using relative paths instead of resolving them against the project root.

## Changes
- Updated the `file_path` assignment in `prune_deleted_files` to properly use `project_root / file_key`.

## Checklist
- [ ] `make pre-commit` passes
- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)

## Related Issues
Closes #13