### PR TITLE
fix(cli): apply inline noqa suppression on the OptimizedScanner path

### DIFF
--- a/src/owasp_agentic_scanner/cli.py
+++ b/src/owasp_agentic_scanner/cli.py
@@ -408,6 +408,13 @@ def scan(
                 files_to_scan_strs = {str(p) for p in files_to_scan}
                 findings = [f for f in findings if str(f.file_path) in files_to_scan_strs]
 
+    # The OptimizedScanner does not apply inline noqa suppression itself, so
+    # filter its findings here to match the legacy scan_codebase() path.
+    # When use_optimized is False (ImportError fallback), scan_codebase()
+    # already filters, so we skip it here to avoid double work.
+    if use_optimized:
+        findings = filter_suppressed(findings)
+
     if not use_optimized:
         # Use original scanner
         if format.lower() == "console":

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -241,6 +241,48 @@ parallel = false
         # Should suppress the finding
         assert result.exit_code == 0
 
+    def test_scan_noqa_suppresses_multiple_rules_on_one_line(self, tmp_path: Path) -> None:
+        """Inline `# noqa: AA04,AA05` should suppress every listed rule on the line.
+
+        Regression test for the OptimizedScanner path, which previously never
+        applied filter_suppressed(), so multi-rule suppressions leaked through.
+        `pickle.loads(...)` triggers both AA04 and AA05 on the same line.
+        """
+        output_file = tmp_path / "results.json"
+
+        # Sanity check: without suppression both findings are reported.
+        unsuppressed = tmp_path / "unsuppressed.py"
+        unsuppressed.write_text("pickle.loads(data)\n")
+        runner.invoke(
+            app, ["scan", str(unsuppressed), "--format", "json", "--output", str(output_file)]
+        )
+        rule_ids = {f["rule_id"] for f in json.loads(output_file.read_text())["findings"]}
+        assert {"AA04", "AA05"} <= rule_ids
+
+        # With a multi-rule noqa, both findings on the line are suppressed.
+        suppressed = tmp_path / "suppressed.py"
+        suppressed.write_text("pickle.loads(data)  # noqa: AA04,AA05\n")
+        result = runner.invoke(
+            app, ["scan", str(suppressed), "--format", "json", "--output", str(output_file)]
+        )
+        findings = json.loads(output_file.read_text())["findings"]
+        assert findings == []
+        assert result.exit_code == 0
+
+    def test_scan_noqa_all_suppresses_every_finding(self, tmp_path: Path) -> None:
+        """Inline `# noqa: ALL` should suppress all findings on the line."""
+        output_file = tmp_path / "results.json"
+        test_file = tmp_path / "test.py"
+        test_file.write_text('eval("2 + 2")  # noqa: ALL\n')
+
+        result = runner.invoke(
+            app, ["scan", str(test_file), "--format", "json", "--output", str(output_file)]
+        )
+
+        findings = json.loads(output_file.read_text())["findings"]
+        assert findings == []
+        assert result.exit_code == 0
+
     def test_scan_json_output_to_stdout(self, tmp_path: Path) -> None:
         """Test JSON output to stdout."""
         test_file = tmp_path / "test.py"


### PR DESCRIPTION
Closes #12

## Problem
`filter_suppressed()` was only called inside the legacy `scan_codebase()` path. The default scanning path — `OptimizedScanner.scan()` — never applied it, so inline suppressions like `# noqa: AA04,AA05` were ignored and the findings were still reported.

## Fix
Apply `filter_suppressed()` to the findings produced by the optimized scanner, right after that block:

```python
if use_optimized:
    findings = filter_suppressed(findings)
```

It's guarded by `if use_optimized` so the `ImportError` fallback — which routes through `scan_codebase()` and **already** filters — is not double-filtered. This also covers the `TypeError` fallback sub-path, which still uses the optimized scanner.

## Why a single guard (and not two inline calls)
Both optimized sub-paths (normal + `TypeError` fallback) keep `use_optimized = True` and assign `findings`; only `ImportError` flips it to `False`. One guarded call after the block therefore covers every optimized case exactly once.

## Tests
Added two integration tests in `tests/integration/test_cli.py`:
- **multi-rule** — `pickle.loads(data)  # noqa: AA04,AA05`. This line triggers **both** AA04 and AA05; before the fix one finding leaked past suppression (verified: 1 finding without the fix → 0 with it). Includes a sanity assertion that both rules fire when *not* suppressed.
- **ALL** — `eval("2 + 2")  # noqa: ALL` suppresses every finding on the line.

## Verification
- Full suite: **296 passed**.
- `ruff check` and `ruff format --check`: clean on both changed files.

## Note (out of scope)
While testing I noticed a separate, pre-existing over-suppression: a non-matching code like `# noqa: AA99` still suppresses other rules on the line, because `ast_analyzer.py` treats *any* `# noqa` as a full-line suppression regardless of rule ID. That's unrelated to this issue, so I left it alone — happy to file a follow-up issue if useful.